### PR TITLE
调整TranslationX计算

### DIFF
--- a/effectivecard/src/main/java/com/codemx/effectivecard/LauncherOverlayView.java
+++ b/effectivecard/src/main/java/com/codemx/effectivecard/LauncherOverlayView.java
@@ -40,16 +40,18 @@ public class LauncherOverlayView extends FrameLayout {
     }
 
     private float mStartX;
+    private float mTranslationX;
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         switch (event.getAction()) {
             case MotionEvent.ACTION_DOWN:
                 mStartX = event.getRawX();
+                mTranslationX = getTranslationX() % getResources().getDisplayMetrics().widthPixels;
                 XLog.d(XLog.getTag(), "ACTION_DOWN= " + event.getRawX());
                 break;
             case MotionEvent.ACTION_MOVE:
-                setTranslationX(getTranslationX()%getResources().getDisplayMetrics().widthPixels + (int) (event.getRawX() - mStartX));
+                setTranslationX(mTranslationX + (int) (event.getRawX() - mStartX));
                 break;
             case MotionEvent.ACTION_UP:
                 break;


### PR DESCRIPTION
当前TranslationX计算会导致滑动时，overlay内的内容X轴偏移值飘忽不定
经调整可以固定X轴偏移值